### PR TITLE
Fixed typo in compute_riemannian_matern_kernel_constant

### DIFF
--- a/BoManifolds/kernel_utils/kernels_sphere.py
+++ b/BoManifolds/kernel_utils/kernels_sphere.py
@@ -400,9 +400,9 @@ def compute_riemannian_matern_kernel_constant(n, d):
     """
     dn = (2*n+d-1) * math.gamma(n+d-1) / math.gamma(d) / math.gamma(n+1)
     # Compute Gegenbauer polynomial
-    gpolynomial = gegenbauer_polynomial(n, (d+1.)/2., torch.ones(1))
+    gpolynomial = gegenbauer_polynomial(n, (d-1.)/2., torch.ones(1))
     # Constant value
-    cnd = dn * math.gamma((d+1.)/2.) / (2*math.pow(math.pi, (d+1.)/2.) * gpolynomial)
+    cnd = dn * math.gamma((d-1.)/2.) / (2*math.pow(math.pi, (d-1.)/2.) * gpolynomial)
     return cnd
 
 


### PR DESCRIPTION
There were three occurrences of "d+1." in kernel_utils.kernels_sphere.compute_riemannian_matern_kernel, which should have been "d-1."

Here is a comparison of SphereRiemannianMaternKernel vs MaternKarhunenLoeveKernel from https://github.com/GPflow/GeometricKernels before and after fixing this typo

![kernel_value_vs_spherical_distance_before_fix](https://github.com/NoemieJaquier/MaternGaBO/assets/71651645/d321e550-48e0-4877-b570-eacaeeca1c96)
![kernel_value_vs_spherical_distance_after_fix](https://github.com/NoemieJaquier/MaternGaBO/assets/71651645/f210a41b-cddb-47b2-b079-6491369efe32)

